### PR TITLE
Account for `sirepo-bluesky` API change

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,7 +29,7 @@ jobs:
           export REPOSITORY_NAME=${GITHUB_REPOSITORY#*/}  # just the repo, as opposed to org/repo
           echo "REPOSITORY_NAME=${REPOSITORY_NAME}" >> $GITHUB_ENV
 
-          export USE_SIREPO=1
+          export USE_SIREPO=yes
           echo "USE_SIREPO=${USE_SIREPO}" >> $GITHUB_ENV
 
       - name: Checkout the code
@@ -50,7 +50,7 @@ jobs:
           set -vxeo pipefail
           conda env list
           # mamba install -c conda-forge -y numpy matplotlib ipython ophyd bluesky databroker sirepo-bluesky
-          pip install numpy matplotlib ipython ophyd bluesky databroker sirepo-bluesky nslsii
+          pip install -r requirements.txt
 
           pip list
           conda list

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@
 Prepare the environment by following the instructions at
 https://nsls-ii.github.io/sirepo-bluesky/installation.html.
 
-We are using simulation with sim_id=`00000003`. See
+We are using simulation with sim_id=`00000004`. See
 https://nsls-ii.github.io/sirepo-bluesky/simulations.html for more details.
 
 ```bash
 $ conda activate <conda-env>  # with sirepo-bluesky, bluesky, ophyd, databroker, etc.
-$ pip install nslsii openpyxl  # additional packages, not listed in the requirements.
+$ pip install -r requirements.txt  # additional packages, not listed in the requirements.
 $ git clone https://github.com/NSLS-II-ARI/profile_sirepo_ari && cd profile_sirepo_ari/
-$ ipython --profile-dir=.
+$ USE_SIREPO=yes ipython --profile-dir=.
 ```
 
 ## Run a scan

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ipython
 nslsii
-sirepo-bluesky
+sirepo-bluesky>=0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
+bluesky
+databroker
 ipython
+matplotlib
 nslsii
+numpy
+ophyd
 sirepo-bluesky>=0.7.0

--- a/startup/10-sirepo.py
+++ b/startup/10-sirepo.py
@@ -21,7 +21,6 @@ if USE_SIREPO:
     # simulations.
     data, schema = connection.auth("srw", "00000004")
     classes, objects = create_classes(
-        connection.data,
         connection=connection,
         extra_model_fields=["undulator", "intensityReport"],
     )


### PR DESCRIPTION
There was a change/simplification on the `create_classes` function signature, so the `connection.data` does not need to be passed to the function, introduced in v0.7.0 (see https://github.com/NSLS-II/sirepo-bluesky/issues/140 for details).